### PR TITLE
Standardize Meta event payloads

### DIFF
--- a/src/app/api/offline/day-nammae/apply/route.ts
+++ b/src/app/api/offline/day-nammae/apply/route.ts
@@ -584,6 +584,11 @@ export async function POST(request: Request) {
     const utmContent = (formData.get("utm_content") as string) || "";
     const fbp = getOptionalString(formData, "fbp");
     const fbc = getOptionalString(formData, "fbc");
+    const metaCompleteRegistrationEventId = getOptionalString(
+      formData,
+      "meta_complete_registration_event_id"
+    );
+    const metaCheckoutEventId = getOptionalString(formData, "meta_checkout_event_id");
 
     maskedPhone = maskPhoneNumber(phone);
 
@@ -850,6 +855,10 @@ export async function POST(request: Request) {
       utm_content: utmContent,
       ...(fbp ? { fbp } : {}),
       ...(fbc ? { fbc } : {}),
+      ...(metaCompleteRegistrationEventId
+        ? { metaCompleteRegistrationEventId }
+        : {}),
+      ...(metaCheckoutEventId ? { metaCheckoutEventId } : {}),
       "Q. 전화번호": phone,
       "Q. 기대되는점": "",
       "[일일남매] 일정 선택": schedule,

--- a/src/components/day-nammae/apply/LoveBuddiesApplyFlow.tsx
+++ b/src/components/day-nammae/apply/LoveBuddiesApplyFlow.tsx
@@ -34,7 +34,11 @@ import {
   DayNammeFormValues,
   ScheduleItem,
 } from "@/features/day-nammae/types";
-import { safeFbq } from "@/utils/metaPixel";
+import {
+  buildDayNammaeMetaEventId,
+  safeFbq,
+  trackDayNammaeMetaStandardEvent,
+} from "@/utils/metaPixel";
 import { trackGAEvent } from "@/utils/gtag";
 import { getSafeSearchParams } from "@/utils/utm";
 import ApplyStepShell from "./ApplyStepShell";
@@ -49,16 +53,6 @@ import StepWaitlistContact from "./steps/StepWaitlistContact";
 
 function trackEvent(eventName: string, params?: Record<string, unknown>) {
   safeFbq("trackCustom", eventName, params);
-}
-
-function trackCompleteRegistration() {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  safeFbq("track", "CompleteRegistration", {
-    content_name: "일일남매",
-  });
 }
 
 function toAnalyticsBoolean(value: boolean | null) {
@@ -194,6 +188,7 @@ interface CheckoutState {
   finalPrice: number;
   couponLabel: string;
   isDiscounted: boolean;
+  metaCheckoutEventId: string;
 }
 
 interface SubmitState {
@@ -1567,7 +1562,8 @@ function formatPrice(value: number) {
 
 function buildCheckoutState(
   scheduleLabel: string,
-  coupon?: Partial<CouponValidationResult & CouponUseResult> | null
+  coupon?: Partial<CouponValidationResult & CouponUseResult> | null,
+  clientRequestId = ""
 ): CheckoutState {
   const discountRate = getCouponDiscountRate(coupon);
   const normalLink =
@@ -1607,6 +1603,10 @@ function buildCheckoutState(
     finalPrice,
     couponLabel: coupon?.discount_label || "",
     isDiscounted,
+    metaCheckoutEventId: buildDayNammaeMetaEventId(
+      "InitiateCheckout",
+      clientRequestId || `${scheduleLabel}:${Date.now()}`
+    ),
   };
 }
 
@@ -2612,6 +2612,14 @@ export default function LoveBuddiesApplyFlow({
     setFormError("");
 
     const clientRequestId = createClientRequestId();
+    const completeRegistrationEventId = buildDayNammaeMetaEventId(
+      "CompleteRegistration",
+      clientRequestId
+    );
+    const checkoutEventId = buildDayNammaeMetaEventId(
+      "InitiateCheckout",
+      clientRequestId
+    );
     const clientDebugContext = buildClientDebugContext(formValues.photo, clientRequestId);
     let submitStage = submitState.applicationSubmitted
       ? "client:coupon-use:retry"
@@ -2659,6 +2667,11 @@ export default function LoveBuddiesApplyFlow({
           requestBody.append("fbc", fbc);
         }
         requestBody.append("client_request_id", clientRequestId);
+        requestBody.append(
+          "meta_complete_registration_event_id",
+          completeRegistrationEventId
+        );
+        requestBody.append("meta_checkout_event_id", checkoutEventId);
         if (wantsCoupon && validatedCoupon) {
           requestBody.append("usedCouponId", String(validatedCoupon.id));
           requestBody.append("couponCode", validatedCoupon.code);
@@ -2729,7 +2742,13 @@ export default function LoveBuddiesApplyFlow({
           result: "success",
           application_submitted: "true",
         });
-        trackCompleteRegistration();
+        trackDayNammaeMetaStandardEvent("CompleteRegistration", {
+          value: BASE_PRICE,
+          eventId: completeRegistrationEventId,
+          schedule: formValues.schedule,
+          couponApplied: wantsCoupon,
+          couponLabel: validatedCoupon?.discount_label,
+        });
       }
 
       let checkoutSource: Partial<CouponValidationResult & CouponUseResult> | null = null;
@@ -2781,7 +2800,11 @@ export default function LoveBuddiesApplyFlow({
         return;
       }
 
-      const checkout = buildCheckoutState(formValues.schedule, checkoutSource);
+      const checkout = buildCheckoutState(
+        formValues.schedule,
+        checkoutSource,
+        clientRequestId
+      );
       trackApplyAnalyticsEvent("dn_checkout_ready", {
         result: "success",
         payment_required: "true",
@@ -3210,10 +3233,12 @@ export default function LoveBuddiesApplyFlow({
               coupon_applied: checkout.isDiscounted,
               coupon_label: checkout.couponLabel,
             });
-            safeFbq("track", "InitiateCheckout", {
+            trackDayNammaeMetaStandardEvent("InitiateCheckout", {
               value: checkout.value,
-              currency: "KRW",
-              content_name: "일일남매",
+              eventId: checkout.metaCheckoutEventId,
+              schedule: formValues.schedule,
+              couponApplied: checkout.isDiscounted,
+              couponLabel: checkout.couponLabel,
             });
           }}
           className="mt-6 inline-flex h-12 w-full items-center justify-center rounded-full bg-[#FF6B9F] text-base font-bold text-white transition active:scale-[0.98]"

--- a/src/utils/metaPixel.ts
+++ b/src/utils/metaPixel.ts
@@ -1,5 +1,8 @@
 export const LOVE_BUDDIES_PIXEL_ID = "1541266446734040";
 export const SSOBIG_STORY_PIXEL_ID = "2156713988421222";
+export const META_EVENT_CURRENCY = "KRW";
+export const DAY_NAMMAE_CONTENT_NAME = "일일남매";
+export const DAY_NAMMAE_CONTENT_ID = "day-nammae";
 
 declare global {
   interface Window {
@@ -18,6 +21,61 @@ export function safeFbq(...args: unknown[]) {
   } catch (error) {
     console.error("Meta Pixel 호출 실패:", error);
   }
+}
+
+type MetaStandardEventName = "CompleteRegistration" | "InitiateCheckout";
+
+interface DayNammaeStandardEventParams {
+  value: number;
+  eventId?: string;
+  schedule?: string;
+  couponApplied?: boolean;
+  couponLabel?: string;
+}
+
+function normalizeMetaValue(value: number) {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+
+  return Math.round(value);
+}
+
+function buildDayNammaeMetaParams(params: DayNammaeStandardEventParams) {
+  return {
+    value: normalizeMetaValue(params.value),
+    currency: META_EVENT_CURRENCY,
+    content_name: DAY_NAMMAE_CONTENT_NAME,
+    content_ids: [DAY_NAMMAE_CONTENT_ID],
+    content_type: "product",
+    ...(params.schedule ? { schedule: params.schedule } : {}),
+    ...(typeof params.couponApplied === "boolean"
+      ? { coupon_applied: params.couponApplied }
+      : {}),
+    ...(params.couponLabel ? { coupon_label: params.couponLabel } : {}),
+  };
+}
+
+export function buildDayNammaeMetaEventId(
+  eventName: MetaStandardEventName,
+  requestId: string
+) {
+  return `${DAY_NAMMAE_CONTENT_ID}:${eventName}:${requestId}`;
+}
+
+export function trackDayNammaeMetaStandardEvent(
+  eventName: MetaStandardEventName,
+  params: DayNammaeStandardEventParams
+) {
+  const payload = buildDayNammaeMetaParams(params);
+  const options = params.eventId ? { eventID: params.eventId } : undefined;
+
+  if (options) {
+    safeFbq("track", eventName, payload, options);
+    return;
+  }
+
+  safeFbq("track", eventName, payload);
 }
 
 export function buildMetaPixelPageViewScript(pixelId: string) {


### PR DESCRIPTION
## Summary
- centralize Day Nammae Meta standard event payloads
- add required value/currency/content metadata and eventID for CompleteRegistration and InitiateCheckout
- pass Meta event IDs through the Day Nammae apply API payload for future CAPI deduping

## Verification
- npx tsc --noEmit --pretty false
- npm run build