### PR TITLE
Disable Meta Pixel automatic events

### DIFF
--- a/src/app/legacy/game-orb/demoday/page.tsx
+++ b/src/app/legacy/game-orb/demoday/page.tsx
@@ -287,6 +287,7 @@ export default function DemoDayPage() {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '681386597924392');
             fbq('init', '681386597924392');
             fbq('track', 'PageView');
           `,

--- a/src/app/legacy/game-orb/devils-plan/page.tsx
+++ b/src/app/legacy/game-orb/devils-plan/page.tsx
@@ -23,6 +23,7 @@ export default function DevilsPlanPage() {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '681386597924392');
             fbq('init', '681386597924392');
             fbq('track', 'PageView');
           `,

--- a/src/app/legacy/game-orb/real_genius/page.tsx
+++ b/src/app/legacy/game-orb/real_genius/page.tsx
@@ -323,6 +323,7 @@ export default function RealGeniusPage() {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '681386597924392');
             fbq('init', '681386597924392');
             fbq('track', 'PageView');
           `,

--- a/src/app/legacy/love-buddies/day_nammae/page.tsx
+++ b/src/app/legacy/love-buddies/day_nammae/page.tsx
@@ -59,7 +59,8 @@ export default function DayNammaePage() {
           t.src=v;s=b.getElementsByTagName(e)[0];
           s.parentNode.insertBefore(t,s)}(window, document,'script',
           'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', '1541266446734040');
+          fbq('set', 'autoConfig', false, '1541266446734040');
+            fbq('init', '1541266446734040');
           fbq('track', 'PageView');
         `}
       </Script>

--- a/src/app/legacy/love-buddies/detail/page.tsx
+++ b/src/app/legacy/love-buddies/detail/page.tsx
@@ -227,7 +227,8 @@ export default function LoveBuddiesDetailPage() {
           t.src=v;s=b.getElementsByTagName(e)[0];
           s.parentNode.insertBefore(t,s)}(window, document,'script',
           'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', '1541266446734040');
+          fbq('set', 'autoConfig', false, '1541266446734040');
+            fbq('init', '1541266446734040');
           fbq('track', 'PageView');
         `}
       </Script>

--- a/src/app/legacy/love-buddies/detail2/page.tsx
+++ b/src/app/legacy/love-buddies/detail2/page.tsx
@@ -133,6 +133,7 @@ export default function LoveBuddiesPage() {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '1541266446734040');
             fbq('init', '1541266446734040');
             fbq('track', 'PageView');
           `,

--- a/src/app/legacy/socialing/game-orb/event/page.tsx
+++ b/src/app/legacy/socialing/game-orb/event/page.tsx
@@ -23,6 +23,7 @@ const SocialGeniusPage = () => {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '681386597924392');
             fbq('init', '681386597924392');
             fbq('track', 'PageView');
           `,

--- a/src/app/legacy/socialing/game-orb/page.tsx
+++ b/src/app/legacy/socialing/game-orb/page.tsx
@@ -140,6 +140,7 @@ export default function GameOrbPage() {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '681386597924392');
             fbq('init', '681386597924392');
             fbq('track', 'PageView');
           `,

--- a/src/app/legacy/socialing/love-buddies/page.tsx
+++ b/src/app/legacy/socialing/love-buddies/page.tsx
@@ -21,6 +21,7 @@ const LoveBuddiesPage = () => {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '1541266446734040');
             fbq('init', '1541266446734040');
             fbq('track', 'PageView');
           `,

--- a/src/app/offline/mafia/page.tsx
+++ b/src/app/offline/mafia/page.tsx
@@ -279,6 +279,7 @@ const SocialGeniusPage = () => {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '681386597924392');
             fbq('init', '681386597924392');
             fbq('track', 'PageView');
           `,
@@ -297,7 +298,8 @@ const SocialGeniusPage = () => {
           t.src=v;s=b.getElementsByTagName(e)[0];
           s.parentNode.insertBefore(t,s)}(window, document,'script',
           'https://connect.facebook.net/en_US/fbevents.js');
-          fbq('init', '1541266446734040');
+          fbq('set', 'autoConfig', false, '1541266446734040');
+            fbq('init', '1541266446734040');
           fbq('track', 'PageView');
         `}
       </Script>

--- a/src/app/offline/manito/page.tsx
+++ b/src/app/offline/manito/page.tsx
@@ -250,6 +250,7 @@ const ManitoPage = () => {
             t.src=v;s=b.getElementsByTagName(e)[0];
             s.parentNode.insertBefore(t,s)}(window, document,'script',
             'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('set', 'autoConfig', false, '1541266446734040');
             fbq('init', '1541266446734040');
             fbq('track', 'PageView');
           `,

--- a/src/utils/metaPixel.ts
+++ b/src/utils/metaPixel.ts
@@ -90,6 +90,7 @@ export function buildMetaPixelPageViewScript(pixelId: string) {
     'https://connect.facebook.net/en_US/fbevents.js');
     window.__ssobigMetaPixelIds = window.__ssobigMetaPixelIds || {};
     if (!window.__ssobigMetaPixelIds['${pixelId}']) {
+      fbq('set', 'autoConfig', false, '${pixelId}');
       fbq('init', '${pixelId}');
       window.__ssobigMetaPixelIds['${pixelId}'] = true;
     }


### PR DESCRIPTION
## Summary
- disable Meta Pixel autoConfig before initializing pixels
- prevent automatic SubscribedButtonClick/Microdata-style events from the shared pixel loader
- apply the same guard to legacy hard-coded pixel snippets for the current offline pixels

## Verification
- npx tsc --noEmit --pretty false
- git diff --check

Note: local full build was blocked by low disk space in the temporary clone; Vercel preview should perform the full build.