### PR TITLE
Stop sending Day Nammae custom Meta events

### DIFF
--- a/src/components/day-nammae/apply/LoveBuddiesApplyFlow.tsx
+++ b/src/components/day-nammae/apply/LoveBuddiesApplyFlow.tsx
@@ -36,7 +36,6 @@ import {
 } from "@/features/day-nammae/types";
 import {
   buildDayNammaeMetaEventId,
-  safeFbq,
   trackDayNammaeMetaStandardEvent,
 } from "@/utils/metaPixel";
 import { trackGAEvent } from "@/utils/gtag";
@@ -52,7 +51,8 @@ import StepSchedule from "./steps/StepSchedule";
 import StepWaitlistContact from "./steps/StepWaitlistContact";
 
 function trackEvent(eventName: string, params?: Record<string, unknown>) {
-  safeFbq("trackCustom", eventName, params);
+  void eventName;
+  void params;
 }
 
 function toAnalyticsBoolean(value: boolean | null) {


### PR DESCRIPTION
## Summary
- stop sending DN_* funnel-step custom events to Meta Pixel
- keep the standardized CompleteRegistration and InitiateCheckout events
- keep GA/app analytics untouched

## Verification
- npx tsc --noEmit --pretty false
- git diff --check